### PR TITLE
Meal 모델 생성 및 (급식 api 파싱, DB 저장 로직) 추가

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,7 @@ app.config.from_object('config')
 
 db = SQLAlchemy(app)
 
-from app.api.models import calender
+from app.api.models import calender, meal
 
 
 try:

--- a/app/api/models/meal.py
+++ b/app/api/models/meal.py
@@ -1,0 +1,19 @@
+from app import db
+
+from app.utils.models import BaseModel
+from app.utils.mixins import BaseMixin
+
+
+class MealModel(BaseModel, BaseMixin):
+    __tablename__ = 'api_meal'
+
+    date = db.Column(db.Date, nullable=False)
+    lunch = db.Column(db.String(150), nullable=False)
+
+    def __init__(self, date: str, lunch: str):
+        self.date = date
+        self.lunch = lunch
+
+    @staticmethod
+    def add_lunch(date, lunch):
+        return MealModel(date, lunch).save()

--- a/app/crawlers/meal.py
+++ b/app/crawlers/meal.py
@@ -1,0 +1,41 @@
+import requests, json, re, datetime
+
+from app.api.models.meal import MealModel
+
+
+# 정규식
+pattern = re.compile('[가-힣]+')
+
+data = {
+    'schl_cd': 'B100000662',
+    'type_cd': 'M',
+    'year': '2017',
+    'month': '4'
+}
+
+# url 정의
+url = "https://www.foodsafetykorea.go.kr/portal/sensuousmenu/selectSchoolMonthMealsDetail.do"
+
+res = requests.post(url, data=data)
+
+json_datas = res.text
+json_datas = json.loads(json_datas)['list']
+
+def show_data(data):
+    try:
+        # 날짜
+        date = data['inqry_mm'] + data['dd_date'].zfill(2)
+        date = datetime.datetime.strptime(date, '%Y%m%d').date()
+        # lunch 배열 정리
+        lunch = data['lunch'].split(',')
+        # 음식 이름만 가져오도록 정규표현식으로 처리
+        lunch = list(map(lambda food: pattern.findall(food)[0], lunch))
+        # list -> string으로 변환
+        lunch = ','.join(lunch)
+    except:
+        return False
+
+    # Meal에 레코드 추가
+    MealModel.add_lunch(date, lunch)
+
+list(map(show_data, json_datas))


### PR DESCRIPTION
### crawlers/meal.py
 - foodsafetykorea에서 제공하는 api를 이용하여 파싱
 - Meal.add_lunch을 통해 급식 정보 저장

### api/models/meal.py
 - meal 모델 생성
 - 레코드를 생성 및 저장하는 add_lunch 메소드 추가

### **Todo**: 각 달을 바꿔가며 크롤링할 수 있도록 변경해야 됨