### PR TITLE
Meal 정보 저장 로직 변경

### DIFF
--- a/app/api/models/meal.py
+++ b/app/api/models/meal.py
@@ -8,12 +8,17 @@ class MealModel(BaseModel, BaseMixin):
     __tablename__ = 'api_meal'
 
     date = db.Column(db.Date, nullable=False)
-    lunch = db.Column(db.String(150), nullable=False)
+    detail = db.Column(db.String(150), nullable=False)
 
-    def __init__(self, date: str, lunch: str):
+    def __init__(self, date: str, detail: str):
         self.date = date
-        self.lunch = lunch
+        self.detail = detail
 
     @staticmethod
-    def add_lunch(date, lunch):
-        return MealModel(date, lunch).save()
+    def add_lunch(date: str, detail: str):
+        if not MealModel.get_lunch(date, detail):
+            return MealModel(date, detail).save()
+
+    @staticmethod
+    def get_lunch(date: str, detail: str):
+        return MealModel.query.filter_by(date=date, detail=detail).first()

--- a/app/crawlers/meal.py
+++ b/app/crawlers/meal.py
@@ -6,11 +6,13 @@ from app.api.models.meal import MealModel
 # 정규식
 pattern = re.compile('[가-힣]+')
 
+date = datetime.datetime.now()
+
 data = {
     'schl_cd': 'B100000662',
     'type_cd': 'M',
-    'year': '2017',
-    'month': '4'
+    'year': date.year,
+    'month': date.month
 }
 
 # url 정의
@@ -27,15 +29,15 @@ def show_data(data):
         date = data['inqry_mm'] + data['dd_date'].zfill(2)
         date = datetime.datetime.strptime(date, '%Y%m%d').date()
         # lunch 배열 정리
-        lunch = data['lunch'].split(',')
+        detail = data['lunch'].split(',')
         # 음식 이름만 가져오도록 정규표현식으로 처리
-        lunch = list(map(lambda food: pattern.findall(food)[0], lunch))
+        detail = list(map(lambda food: pattern.findall(food)[0], detail))
         # list -> string으로 변환
-        lunch = ','.join(lunch)
+        detail = ','.join(detail)
     except:
         return False
 
     # Meal에 레코드 추가
-    MealModel.add_lunch(date, lunch)
+    MealModel.add_lunch(date, detail)
 
 list(map(show_data, json_datas))


### PR DESCRIPTION
api/models/meal.py
 - field명 lunch -> detail로 변경
 - 이미 데이터베이스에 등록되어있는 급식 정보는 중복 저장되지 않도록 변경

api/crawlers/meal.py
 - 매개변수명 lunch -> detail로 변경
 - 크롤링하는 급식 날짜(년도, 월)를 datetime으로 접근함으로써 현재 날짜를 기준으로 하도록 변경