### PR TITLE
Calender (table명, db column) 변경 작업

### DIFF
--- a/app/api/models/calender.py
+++ b/app/api/models/calender.py
@@ -5,7 +5,7 @@ from app.utils.mixins import BaseMixin
 
 
 class CalenderModel(BaseModel, BaseMixin):
-    __tablename__ = 'api_calender'
+    __tablename__ = 'Calendars'
 
     month = db.Column(db.Integer, nullable=False)
     date = db.Column(db.Integer, nullable=False)

--- a/app/api/models/calender.py
+++ b/app/api/models/calender.py
@@ -7,18 +7,20 @@ from app.utils.mixins import BaseMixin
 class CalenderModel(BaseModel, BaseMixin):
     __tablename__ = 'api_calender'
 
-    date = db.Column(db.Date, nullable=False)
+    month = db.Column(db.Integer, nullable=False)
+    date = db.Column(db.Integer, nullable=False)
     detail = db.Column(db.String(50), nullable=False)
 
-    def __init__(self, date: str, detail: str):
+    def __init__(self, month: int, date: int, detail: str):
+        self.month = month
         self.date = date
         self.detail = detail
 
     @staticmethod
-    def add_schedule(date, detail: str):
-        if not CalenderModel.get_schedule(date, detail):
-            return CalenderModel(date, detail).save()
+    def add_schedule(month: int, date: int, detail: str):
+        if not CalenderModel.get_schedule(month, date, detail):
+            return CalenderModel(month, date, detail).save()
 
     @staticmethod
-    def get_schedule(date: str, detail: str):
-        return CalenderModel.query.filter_by(date=date, detail=detail).first()
+    def get_schedule(month: int, date: int, detail: str):
+        return CalenderModel.query.filter_by(month=month, date=date, detail=detail).first()

--- a/app/crawlers/calender.py
+++ b/app/crawlers/calender.py
@@ -77,9 +77,7 @@ for options in select_options:
         except:
             continue
 
-        date = datetime.date(year, month, date)
-
         # Calender 레코드 생성 및 저장
-        CalenderModel.add_schedule(date, detail)
+        CalenderModel.add_schedule(month, date, detail)
 
 driver.close()


### PR DESCRIPTION
api/models/calender.py
 - MOD: table명 api_calender -> Calendars 으로 변경
 - MOD: date(년도, 월, 일) column을 month, date(일)로 분할

api/crawlers/calender.py
 - DEL: (year, month, date)로 date 객체를 만드는 로직 제거
 - MOD: low 생성 매개변수로 date가 아닌 (month, date)를 넘기는 것으로 변경