### PR TITLE
Meal field 수정 및 저장 로직 변경

### DIFF
--- a/app/api/models/meal.py
+++ b/app/api/models/meal.py
@@ -5,20 +5,24 @@ from app.utils.mixins import BaseMixin
 
 
 class MealModel(BaseModel, BaseMixin):
-    __tablename__ = 'api_meal'
+    __tablename__ = 'Meals'
 
-    date = db.Column(db.Date, nullable=False)
+    month = db.Column(db.Integer, nullable=False)
+    date = db.Column(db.Integer, nullable=False)
     detail = db.Column(db.String(150), nullable=False)
+    createdAt = None
+    updatedAt = None
 
-    def __init__(self, date: str, detail: str):
+    def __init__(self, month: int, date: int, detail: str):
+        self.month = month
         self.date = date
         self.detail = detail
 
     @staticmethod
-    def add_lunch(date: str, detail: str):
-        if not MealModel.get_lunch(date, detail):
-            return MealModel(date, detail).save()
+    def add_lunch(month: int, date: int, detail: str):
+        if not MealModel.get_lunch(month, date, detail):
+            return MealModel(month, date, detail).save()
 
     @staticmethod
-    def get_lunch(date: str, detail: str):
-        return MealModel.query.filter_by(date=date, detail=detail).first()
+    def get_lunch(month: int, date: int, detail: str):
+        return MealModel.query.filter_by(month=month, date=date, detail=detail).first()

--- a/app/crawlers/meal.py
+++ b/app/crawlers/meal.py
@@ -38,6 +38,6 @@ def show_data(data):
         return False
 
     # Meal에 레코드 추가
-    MealModel.add_lunch(date, detail)
+    MealModel.add_lunch(date.month, date.day, detail)
 
 list(map(show_data, json_datas))


### PR DESCRIPTION
api/models/meal.py
 - ADD: 상속받은 createdAt, updatedAt을 None으로 지정하여 사용하지 않음
 - MOD: date를 month와 date로 나눔
 - MOD: 저장로직의 매개 변수 date를 제거, month와 date로 추가

crawlers/meal.py
 - MOD: 레코드 추가 부분 date -> (month, date)
 - DEL: date 객체 생성 부분 제거